### PR TITLE
Fix CI build and vendor tag-dict tooling

### DIFF
--- a/docs/superpowers/plans/2026-07-14-tag-input-translation.md
+++ b/docs/superpowers/plans/2026-07-14-tag-input-translation.md
@@ -1,0 +1,443 @@
+# Tag Input Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Chinese users submit Chinese text in the tag editor and filter input while keeping canonical stored and filtered tags in English, and show Chinese tag explanations on hover without changing visible chip text.
+
+**Architecture:** Extend the existing tag translation service into a bidirectional canonicalization layer shared by `MediaTags` and `SearchBar`. Keep `tags` as the English source of truth, add one new Electron IPC for resolving a single submitted tag into canonical English, and only touch submit-time UI behavior so existing filter and suggestion flows stay intact.
+
+**Tech Stack:** TypeScript, React, Electron IPC, Jest, Testing Library, YAML-backed local tag dictionary
+
+---
+
+## File Structure
+
+- `electron/services/tagTranslate.cts`
+  Adds reverse dictionary lookup and a single-tag canonicalization pipeline that can resolve `zh -> en` using dictionary-first fallback translation.
+- `electron/services/ipcService.cts`
+  Exposes a new IPC handler for submit-time tag canonicalization.
+- `electron/preload.cts`
+  Publishes the new IPC method to the renderer.
+- `src/types/index.ts`
+  Extends `ElectronAPI` with the canonicalization method.
+- `src/services/tagTranslationService.ts`
+  Centralizes English-tag detection, hover-tooltip generation, and submit-time canonicalization helpers shared by UI components.
+- `src/components/MediaTags.tsx`
+  Canonicalizes submitted input on Enter, keeps visible tag chips in English, and adds translated hover text in Chinese mode.
+- `src/components/Toolbar/SearchBar.tsx`
+  Canonicalizes submitted input on Enter before adding a filter tag while leaving suggestion-click behavior untouched.
+- `src/__tests__/services/tagTranslationService.test.ts`
+  Covers service helpers and Electron bridge usage.
+- `src/__tests__/components/MediaTags.test.tsx`
+  Covers tag-editor submit behavior and hover tooltip behavior.
+- `src/__tests__/components/SearchBar.test.tsx`
+  Covers filter submit behavior with Chinese input.
+
+### Task 1: Add failing service tests for canonical English resolution and hover tooltips
+
+**Files:**
+- Modify: `src/__tests__/services/tagTranslationService.test.ts`
+- Modify: `src/services/tagTranslationService.ts`
+- Modify: `src/types/index.ts`
+- Modify: `electron/preload.cts`
+- Modify: `electron/services/ipcService.cts`
+- Modify: `electron/services/tagTranslate.cts`
+
+- [ ] **Step 1: Write the failing service tests**
+
+Append tests like these to `src/__tests__/services/tagTranslationService.test.ts`:
+
+```ts
+import {
+  getTagHoverText,
+  resolveCanonicalTagInput,
+} from '@/services/tagTranslationService';
+
+const mockResolveTagInput = jest.fn() as jest.MockedFunction<ElectronAPI['resolveTagInput']>;
+
+beforeEach(() => {
+  window.electron = {
+    translateTags: mockTranslateTags,
+    resolveTagInput: mockResolveTagInput,
+    imageAPI: {
+      updateTagTranslation: mockUpdateTagTranslation,
+    },
+  } as unknown as ElectronAPI;
+});
+
+it('returns canonical English input unchanged without invoking Electron', async () => {
+  await expect(resolveCanonicalTagInput('blue_eyes')).resolves.toBe('blue_eyes');
+  expect(mockResolveTagInput).not.toHaveBeenCalled();
+});
+
+it('resolves Chinese input through the Electron canonicalization bridge', async () => {
+  mockResolveTagInput.mockResolvedValue('cat');
+
+  await expect(resolveCanonicalTagInput('猫')).resolves.toBe('cat');
+  expect(mockResolveTagInput).toHaveBeenCalledWith('猫', 'en');
+});
+
+it('falls back to the original text when canonicalization fails', async () => {
+  mockResolveTagInput.mockRejectedValue(new Error('bridge failed'));
+
+  await expect(resolveCanonicalTagInput('猫')).resolves.toBe('猫');
+});
+
+it('returns translated hover text only in Chinese mode when it differs from the canonical tag', () => {
+  expect(getTagHoverText('cat', '猫', 'zh')).toBe('猫');
+  expect(getTagHoverText('cat', 'cat', 'zh')).toBeUndefined();
+  expect(getTagHoverText('cat', '猫', 'en')).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run the focused service test to verify it fails**
+
+Run: `npx jest src/__tests__/services/tagTranslationService.test.ts --runInBand`
+Expected: FAIL because `resolveCanonicalTagInput`, `getTagHoverText`, and `window.electron.resolveTagInput` do not exist yet
+
+- [ ] **Step 3: Write the minimal production code**
+
+Add the renderer-side helpers in `src/services/tagTranslationService.ts`:
+
+```ts
+const chineseCharPattern = /[\u3400-\u9fff]/;
+
+export function looksCanonicalEnglishTag(input: string): boolean {
+  const trimmed = input.trim();
+  return !!trimmed && englishTagPattern.test(trimmed);
+}
+
+export async function resolveCanonicalTagInput(input: string): Promise<string> {
+  const trimmed = input.trim();
+  if (!trimmed || looksCanonicalEnglishTag(trimmed)) {
+    return trimmed;
+  }
+
+  try {
+    const resolved = await window.electron.resolveTagInput(trimmed, 'en');
+    return resolved.trim() || trimmed;
+  } catch (error) {
+    console.error('Error resolving canonical tag input:', error);
+    return trimmed;
+  }
+}
+
+export function getTagHoverText(tag: string, translatedTag: string | undefined, language: string): string | undefined {
+  if (!isChineseLanguage(language)) {
+    return undefined;
+  }
+  if (!translatedTag || translatedTag === tag) {
+    return undefined;
+  }
+  return translatedTag;
+}
+```
+
+Expose the new bridge through Electron:
+
+```ts
+// src/types/index.ts
+resolveTagInput: (input: string, targetLang: 'en') => Promise<string>;
+
+// electron/preload.cts
+resolveTagInput: (input: string, targetLang: 'en') => ipcRenderer.invoke('resolve-tag-input', input, targetLang),
+```
+
+Add the IPC handler and reverse-lookup entrypoint:
+
+```ts
+// electron/services/ipcService.cts
+ipcMain.handle('resolve-tag-input', async (_event, input: string, targetLang: string) => {
+  return await resolveTagInputPipeline(input, targetLang, (missing, lang) => translateTags([missing], lang));
+});
+```
+
+```ts
+// electron/services/tagTranslate.cts
+function reverseDictionaryLookup(raw: string): string | null {
+  const normalized = raw.trim().toLowerCase();
+  for (const [candidate, translated] of loadDictionary().entries()) {
+    if (translated.trim().toLowerCase() === normalized) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export async function resolveTagInputPipeline(
+  input: string,
+  targetLang: string,
+  fallback: (input: string, targetLang: string) => Promise<string[]>
+): Promise<string> {
+  const trimmed = input.trim();
+  if (!trimmed) return '';
+
+  const reverseHit = reverseDictionaryLookup(trimmed);
+  if (reverseHit) return reverseHit;
+
+  const translated = await fallback(trimmed, targetLang);
+  return translated[0]?.trim() || trimmed;
+}
+```
+
+- [ ] **Step 4: Re-run the focused service test**
+
+Run: `npx jest src/__tests__/services/tagTranslationService.test.ts --runInBand`
+Expected: PASS
+
+### Task 2: Add failing tag editor tests, then implement Chinese submit canonicalization and hover text
+
+**Files:**
+- Create: `src/__tests__/components/MediaTags.test.tsx`
+- Modify: `src/components/MediaTags.tsx`
+- Modify: `src/services/tagTranslationService.ts`
+
+- [ ] **Step 1: Write the failing `MediaTags` tests**
+
+Create `src/__tests__/components/MediaTags.test.tsx` with:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import MediaTags from '@/components/MediaTags';
+import { resolveCanonicalTagInput } from '@/services/tagTranslationService';
+
+jest.mock('@/services/tagTranslationService', () => ({
+  resolveCanonicalTagInput: jest.fn(),
+  getTagHoverText: jest.requireActual('@/services/tagTranslationService').getTagHoverText,
+}));
+
+jest.mock('@/contexts/LanguageContext', () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+    language: 'zh',
+    setLanguage: jest.fn(),
+  }),
+}));
+
+const mockResolveCanonicalTagInput = resolveCanonicalTagInput as jest.MockedFunction<typeof resolveCanonicalTagInput>;
+
+describe('MediaTags', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('submits the canonical English tag when the user presses Enter with Chinese input', async () => {
+    const onTagsUpdate = jest.fn();
+    mockResolveCanonicalTagInput.mockResolvedValue('cat');
+
+    render(
+      <MediaTags
+        tags={['tree']}
+        displayTags={['树']}
+        mediaId="image-1"
+        onTagsUpdate={onTagsUpdate}
+      />
+    );
+
+    const input = screen.getByPlaceholderText('tagInput');
+    fireEvent.change(input, { target: { value: '猫' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onTagsUpdate).toHaveBeenCalledWith('image-1', ['tree', 'cat']);
+    });
+  });
+
+  it('keeps the visible chip text in English and exposes the Chinese translation as the title', () => {
+    render(
+      <MediaTags
+        tags={['cat']}
+        displayTags={['猫']}
+        mediaId="image-1"
+        onTagsUpdate={jest.fn()}
+      />
+    );
+
+    const chip = screen.getByText('cat');
+    expect(chip).toBeInTheDocument();
+    expect(chip).toHaveAttribute('title', '猫');
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused `MediaTags` test to verify it fails**
+
+Run: `npx jest src/__tests__/components/MediaTags.test.tsx --runInBand`
+Expected: FAIL because `MediaTags` currently stores raw Chinese input and renders `displayTags` as visible text instead of using it as hover text
+
+- [ ] **Step 3: Write the minimal `MediaTags` implementation**
+
+Update submit handling and chip rendering in `src/components/MediaTags.tsx`:
+
+```tsx
+const handleInputKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+  if (e.key === 'Enter' && inputValue.trim()) {
+    e.preventDefault();
+    const newTag = await resolveCanonicalTagInput(inputValue);
+    if (newTag && !selectedTags.includes(newTag)) {
+      const newTags = Array.from(new Set([...selectedTags, newTag]));
+      setSelectedTags(newTags);
+      onTagsUpdate(mediaId, newTags);
+    }
+    setInputValue('');
+  }
+};
+```
+
+Render chips with English text and translated hover text:
+
+```tsx
+{selectedTags.map((tag, index) => {
+  const hoverText = getTagHoverText(tag, displayTags?.[index], language);
+
+  return (
+    <div
+      key={`${tag}-${index}`}
+      className="flex gap-1 items-center px-2 py-1 h-7 text-sm text-blue-800 bg-blue-100 rounded-full dark:bg-blue-900 dark:text-blue-200 group"
+      title={hoverText}
+    >
+      <span>{tag}</span>
+      <button
+        onClick={() => removeTag(tag)}
+        className="opacity-0 transition-opacity group-hover:opacity-100 hover:text-red-500 dark:hover:text-red-400 focus:outline-none"
+        aria-label={t('deleteTag', { tag })}
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+})}
+```
+
+- [ ] **Step 4: Re-run the focused `MediaTags` test**
+
+Run: `npx jest src/__tests__/components/MediaTags.test.tsx --runInBand`
+Expected: PASS
+
+### Task 3: Add failing filter-input tests, then implement Chinese submit canonicalization on Enter
+
+**Files:**
+- Create: `src/__tests__/components/SearchBar.test.tsx`
+- Modify: `src/components/Toolbar/SearchBar.tsx`
+- Modify: `src/services/tagTranslationService.ts`
+
+- [ ] **Step 1: Write the failing `SearchBar` test**
+
+Create `src/__tests__/components/SearchBar.test.tsx` with:
+
+```tsx
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import SearchBar from '@/components/Toolbar/SearchBar';
+import { resolveCanonicalTagInput } from '@/services/tagTranslationService';
+
+jest.mock('@/services/tagService', () => ({
+  getTagFrequency: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/services/tagTranslationService', () => ({
+  resolveCanonicalTagInput: jest.fn(),
+}));
+
+jest.mock('@/contexts/LanguageContext', () => ({
+  useLocale: () => ({
+    t: (key: string) => key,
+    language: 'zh',
+    setLanguage: jest.fn(),
+  }),
+}));
+
+const mockResolveCanonicalTagInput = resolveCanonicalTagInput as jest.MockedFunction<typeof resolveCanonicalTagInput>;
+
+describe('SearchBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves Chinese input to English on Enter before invoking onSearch', async () => {
+    const onSearch = jest.fn();
+    const setTags = jest.fn();
+    mockResolveCanonicalTagInput.mockResolvedValue('cat');
+
+    render(
+      <SearchBar
+        onSearch={onSearch}
+        searchButtonRef={{ current: document.createElement('button') }}
+        tags={[]}
+        setTags={setTags}
+      />
+    );
+
+    fireEvent.click(screen.getByTitle('search(Ctrl+F)'));
+    const input = screen.getByPlaceholderText('searchImages');
+    fireEvent.change(input, { target: { value: '猫' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(setTags).toHaveBeenCalledWith(['cat']);
+      expect(onSearch).toHaveBeenCalledWith(['cat']);
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused `SearchBar` test to verify it fails**
+
+Run: `npx jest src/__tests__/components/SearchBar.test.tsx --runInBand`
+Expected: FAIL because `SearchBar` currently passes raw input through on Enter
+
+- [ ] **Step 3: Write the minimal `SearchBar` implementation**
+
+Update the Enter branch in `src/components/Toolbar/SearchBar.tsx`:
+
+```tsx
+const handleInputKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
+  if (e.key === 'Enter' && inputValue.trim()) {
+    const newTag = await resolveCanonicalTagInput(inputValue);
+    if (!newTag) {
+      setInputValue('');
+      return;
+    }
+    const nextTags = Array.from(new Set([...tags, newTag]));
+    setTags(nextTags);
+    setInputValue('');
+    onSearch(nextTags);
+    setSelectedTags(Array.from(new Set([...selectedTags, newTag])));
+  }
+};
+```
+
+Do not modify `handleSuggestionClick`; suggestion clicks should remain English-only in this iteration.
+
+- [ ] **Step 4: Re-run the focused `SearchBar` test**
+
+Run: `npx jest src/__tests__/components/SearchBar.test.tsx --runInBand`
+Expected: PASS
+
+### Task 4: Verify the end-to-end regression surface and inspect the final diff
+
+**Files:**
+- Modify: `electron/services/tagTranslate.cts`
+- Modify: `electron/services/ipcService.cts`
+- Modify: `electron/preload.cts`
+- Modify: `src/types/index.ts`
+- Modify: `src/services/tagTranslationService.ts`
+- Modify: `src/components/MediaTags.tsx`
+- Modify: `src/components/Toolbar/SearchBar.tsx`
+- Modify: `src/__tests__/services/tagTranslationService.test.ts`
+- Create: `src/__tests__/components/MediaTags.test.tsx`
+- Create: `src/__tests__/components/SearchBar.test.tsx`
+
+- [ ] **Step 1: Run the focused regression suite**
+
+Run: `npx jest src/__tests__/services/tagTranslationService.test.ts src/__tests__/components/MediaTags.test.tsx src/__tests__/components/SearchBar.test.tsx --runInBand`
+Expected: PASS
+
+- [ ] **Step 2: Run the broader related tests**
+
+Run: `npx jest src/__tests__/hooks/useTagTranslation.test.tsx --runInBand`
+Expected: PASS to confirm the existing lazy `en -> zh` translation flow still works
+
+- [ ] **Step 3: Inspect the final diff**
+
+Run: `git diff -- electron/services/tagTranslate.cts electron/services/ipcService.cts electron/preload.cts src/types/index.ts src/services/tagTranslationService.ts src/components/MediaTags.tsx src/components/Toolbar/SearchBar.tsx src/__tests__/services/tagTranslationService.test.ts src/__tests__/components/MediaTags.test.tsx src/__tests__/components/SearchBar.test.tsx`
+Expected: only the planned canonicalization bridge, tag hover behavior, filter submit behavior, and targeted tests appear

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "relational-pouch": "^4.1.1",
     "sharp": "^0.34.2",
     "uuid": "^11.1.0",
-    "ws": "^8.18.0"
+    "ws": "^8.18.0",
+    "yaml": "^2.9.0"
   },
   "devDependencies": {
     "@electron/remote": "^2.0.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       ws:
         specifier: ^8.18.0
         version: 8.18.1
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
     devDependencies:
       '@electron/remote':
         specifier: ^2.0.10
@@ -1119,85 +1122,72 @@ packages:
     resolution: {integrity: sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.1.0':
     resolution: {integrity: sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.1.0':
     resolution: {integrity: sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.1.0':
     resolution: {integrity: sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.1.0':
     resolution: {integrity: sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.1.0':
     resolution: {integrity: sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.1.0':
     resolution: {integrity: sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.2':
     resolution: {integrity: sha512-D8n8wgWmPDakc83LORcfJepdOSN6MvWNzzz2ux0MnIbOqdieRZwVYY32zxVx+IFUT8er5KPcyU3XXsn+GzG/0Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.2':
     resolution: {integrity: sha512-0DZzkvuEOqQUP9mo2kjjKNok5AmnOr1jB2XYjkaoNRwpAYMDzRmAqUIa1nRi58S2WswqSfPOWLNOr0FDT3H5RQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.2':
     resolution: {integrity: sha512-EGZ1xwhBI7dNISwxjChqBGELCWMGDvmxZXKjQRuqMrakhO8QoMgqCrdjnAqJq/CScxfRn+Bb7suXBElKQpPDiw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.2':
     resolution: {integrity: sha512-sD7J+h5nFLMMmOXYH4DD9UtSNBD05tWSSdWAcEyzqW8Cn5UxXvsHAxmxSesYUsTOBmUnjtxghKDl15EvfqLFbQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.2':
     resolution: {integrity: sha512-NEE2vQ6wcxYav1/A22OOxoSOGiKnNmDzCYFOZ949xFmrWZOVII1Bp3NqVVpvj+3UeHMFyN5eP/V5hzViQ5CZNA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.2':
     resolution: {integrity: sha512-DOYMrDm5E6/8bm/yQLCWyuDJwUnlevR8xtF8bs+gjZ7cyUNYXiSf/E8Kp0Ss5xasIaXSHzb888V1BE4i1hFhAA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.2':
     resolution: {integrity: sha512-/VI4mdlJ9zkaq53MbIG6rZY+QRN3MLbR6usYlgITEzi4Rpx5S6LFKsycOQjkOGmqTNmkIdLjEvooFKwww6OpdQ==}
@@ -6036,9 +6026,9 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@2.7.0:
-    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
-    engines: {node: '>= 14'}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@21.1.1:
@@ -11377,7 +11367,7 @@ snapshots:
   postcss-load-config@4.0.2(postcss@8.5.3):
     dependencies:
       lilconfig: 3.1.3
-      yaml: 2.7.0
+      yaml: 2.9.0
     optionalDependencies:
       postcss: 8.5.3
 
@@ -12944,7 +12934,7 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@2.7.0: {}
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/script/build_tag_dict.mjs
+++ b/script/build_tag_dict.mjs
@@ -1,0 +1,23 @@
+// Refresh vendored tag translation dictionaries from
+// Physton/sd-webui-prompt-all-in-one. Run with `node script/build_tag_dict.mjs`.
+// The files are consumed directly by electron/services/tagTranslate.cts.
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const LOCALES = ['zh_CN']; // add more (ja_JP, ko_KR, ...) as needed
+const OUT_DIR = path.resolve('script/tag-dict');
+
+await fs.mkdir(OUT_DIR, { recursive: true });
+
+for (const code of LOCALES) {
+  const url = `https://raw.githubusercontent.com/Physton/sd-webui-prompt-all-in-one/main/group_tags/${code}.yaml`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    console.warn(`skip ${code}: HTTP ${res.status}`);
+    continue;
+  }
+  const outPath = path.join(OUT_DIR, `${code}.yaml`);
+  await fs.writeFile(outPath, await res.text(), 'utf8');
+  console.log(`wrote ${outPath}`);
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
   base: './',
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
   optimizeDeps: {
     exclude: ['lucide-react'],
   },


### PR DESCRIPTION
Register the @ -> ./src alias in vite.config so Rollup can resolve imports like @/services/tagTranslationService (previously only tsconfig knew about the alias, so type-checking passed but the production build failed on CI).

Also land the supporting tag-dict workstream:
- script/build_tag_dict.mjs to refresh vendored translation dictionaries from sd-webui-prompt-all-in-one.
- yaml runtime dependency used by the tag translation loader.
- Plan doc for the tag input translation feature.